### PR TITLE
remove FOSS label from RePainter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,7 +1047,7 @@ Widgets that require KWGT or any other paid components **SHOULD BE MENTIONED**
 -  `🧋 FOSS`  [LinkSheet](https://github.com/1fexd/LinkSheet)
 > Restores the old App chooser when clicking on an url!
 
--# `🧋 FOSS`  [Rays](https://github.com/SkyD666/Rays-Android/issues/2#issuecomment-1556195236)
+-  `🧋 FOSS`  [Rays](https://github.com/SkyD666/Rays-Android/issues/2#issuecomment-1556195236)
 > An app to manage stickers and memes! (i linked to the english version)
 
 -  `🧋 FOSS`  [Atomic](https://play.google.com/store/apps/details?id=com.jlindemann.science)

--- a/README.md
+++ b/README.md
@@ -952,7 +952,7 @@ Widgets that require KWGT or any other paid components **SHOULD BE MENTIONED**
 
   
 
--  `☕`  `🍵 Steps Required`  `🧋 FOSS`  [RePainter](https://play.google.com/store/apps/details?id=dev.kdrag0n.dyntheme)
+-  `☕`  `🍵 Steps Required`  [RePainter](https://play.google.com/store/apps/details?id=dev.kdrag0n.dyntheme)
 > Transform your entire material you, it has more themes! (and more customization if you get the pro version!)
 
   

--- a/README.md
+++ b/README.md
@@ -1047,7 +1047,7 @@ Widgets that require KWGT or any other paid components **SHOULD BE MENTIONED**
 -  `🧋 FOSS`  [LinkSheet](https://github.com/1fexd/LinkSheet)
 > Restores the old App chooser when clicking on an url!
 
--  `🧋 FOSS`  [Rays](https://github.com/SkyD666/Rays-Android/issues/2#issuecomment-1556195236)
+-  `🧋 FOSS`  [Rays](https://github.com/SkyD666/Rays-Android/blob/master/doc/README/README-en.md)
 > An app to manage stickers and memes! (i linked to the english version)
 
 -  `🧋 FOSS`  [Atomic](https://play.google.com/store/apps/details?id=com.jlindemann.science)


### PR DESCRIPTION
- Removes the `🧋 FOSS` label from [RePainter](https://play.google.com/store/apps/details?id=dev.kdrag0n.dyntheme), as it proprietary
-  Fixes a typo, where a `#` stop markdown from rendering a bullet point correctly
- Links to the [English README of Rays](https://github.com/SkyD666/Rays-Android/blob/master/doc/README/README-en.md) directly

I also noticed that this list still links to the archived version of [VancedMicroG](https://github.com/inotia00/VancedMicroG). A replacement has been made available in the form of [mMicroG](https://github.com/inotia00/mMicroG). I'm not sure if it's intentional, as it is mentioned that it is outdated?